### PR TITLE
adding device name configuration, and setting light state

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Home bridge Plugin for Connected by TCP
 
 # Setting up your TCP Lights
-Fixtures are ignored - is explose each as an individual bulb.
+Fixtures are ignored - each individual bulb is exposed.
 
 # Installation
  * Install homebridge using: npm install -g homebridge
@@ -32,7 +32,26 @@ Afterwards, add the token to your config and restart homebridge.
          "platform": "ConnectedByTcp",
          "name": "ConnectedByTcp",
          "ip": "172.16.1.40",
-         "loglevel":"3"         
+         "loglevel":"3",
+         "token":"e2de937chr0lhrlqd6bus3l2z5jcy5p3vs7013bq"
+       }
+    ],
+```
+
+Optionally, set names for the deviceids in Homekit:
+
+```
+    "platforms": [
+       {
+         "platform": "ConnectedByTcp",
+         "name": "ConnectedByTcp",
+         "ip": "172.16.1.40",
+         "loglevel":"3",
+         "token":"e2de937chr0lhrlqd6bus3l2z5jcy5p3vs7013bq",
+         "deviceNames": {
+           "219373657216334108": "Desk Lamp",
+           "219373657216334927": "Stand Lamp"
+         }
        }
     ],
 ```
@@ -478,7 +497,7 @@ Example Response:
     </gdata>
   </gwrcmd>
 </gwrcmds>
-``` 
+```
 
 # Thanks
 

--- a/config-sample.json
+++ b/config-sample.json
@@ -5,14 +5,19 @@
         "port": 51826,
         "pin": "031-45-154"
     },
-    
+
     "description": "This is an example configuration file with one fake accessory and one fake platform. You can use this as a template for creating your own configuration file containing devices you actually own.",
     "platforms": [
        {
          "platform": "ConnectedByTcp",
          "name": "ConnectedByTcp",
          "ip": "172.16.1.40",
-         "loglevel":"0"
+         "loglevel":"0",
+         "token":"aaaabbbbccccddddeeeeffffgggghhhhiiiijjjj",
+         "deviceNames": {
+           "219373657216334108": "Desk Lamp",
+           "219373657216334927": "Stand Lamp"
+         }
        }
     ],
     "accessories": []


### PR DESCRIPTION
It looks like you inadvertently removed the call to set the state for your level fix. For me, the result was that Homekit wasn't reporting the on/off state correctly.

Also, I found it useful to put names to the deviceids, so I didn't have to change their labels in the iOS Home app.

Sorry for all the whitespace commit differences. It looks like my text editor did some automatic whitespace cleanup.